### PR TITLE
Add readme pointers to latest developments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Simmy
-Simmy is a chaos-engineering and fault-injection tool, integrating with the Polly resilience project for .NET
+Simmy is a chaos-engineering and fault-injection tool, integrating with the Polly resilience project for .NET.  It is expected to release in early 2019 and will work with Polly v7.0.
+
+## Advance information
+
+For background on the original proposal for a fault-injection dimension to Polly, see [the original issue on the Polly repo](https://github.com/App-vNext/Polly/issues/499).
+
+See the [v0_1 branch](https://github.com/App-vNext/Simmy/tree/v0_1) for the latest Simmy code.  Prior to a [Polly v7.0 release on nuget](https://www.nuget.org/packages/Polly/7.0.0), Simmy can still be trialled right now, using a nuget build from the [v7.0 branch of Polly](https://github.com/App-vNext/Polly/tree/v700).   
+
+See [Issues](https://github.com/App-vNext/Simmy/issues) for latest discussions as we bring Simmy towards release!


### PR DESCRIPTION
Add some pointers in the current `master` readme on Simmy, to where the main discussion is happening.

(Expect to remove the text added in this commit, before we merge the v0_1 branch to master.)