### PR TITLE
Makes cancellable configuration-providing delegates

### DIFF
--- a/src/Polly.Contrib.Simmy.Specs/Fault/InjectFaultAsyncSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Fault/InjectFaultAsyncSpecs.cs
@@ -69,7 +69,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             var policy = MonkeyPolicy.InjectFaultAsync(
                 new Exception("test"),
                 0.6,
-                async (ctx) =>
+                async (ctx, ct) =>
                 {
                     return await Task.FromResult((bool)ctx["ShouldFail"]);
                 });
@@ -89,7 +89,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             var policy = MonkeyPolicy.InjectFaultAsync(
                 new Exception("test"),
                 0.4,
-                async (ctx) =>
+                async (ctx, ct) =>
                 {
                     return await Task.FromResult((bool)ctx["ShouldFail"]);
                 });
@@ -108,7 +108,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             var policy = MonkeyPolicy.InjectFaultAsync(
                 new Exception("test"),
                 0.6,
-                async (ctx) =>
+                async (ctx, ct) =>
                 {
                     return await Task.FromResult((bool)ctx["ShouldFail"]);
                 });
@@ -128,8 +128,8 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             Context context = new Context();
 
             Func<Context, CancellationToken, Task<Exception>> fault = (ctx, cts) => Task.FromResult(new Exception());
-            Func<Context, Task<bool>> enabled = (ctx) => Task.FromResult(true);
-            Func<Context, Task<Double>> injectionRate = (ctx) => Task.FromResult(-0.1);
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) => Task.FromResult(true);
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) => Task.FromResult(-0.1);
             var policy = MonkeyPolicy.InjectFaultAsync(fault, injectionRate, enabled);
 
             Func<Context, Task> actionAsync = (_) => { executed = true; return TaskHelper.EmptyTask; };
@@ -144,8 +144,8 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             Context context = new Context();
 
             Func<Context, CancellationToken, Task<Exception>> fault = (ctx, cts) => Task.FromResult(new Exception());
-            Func<Context, Task<bool>> enabled = (ctx) => Task.FromResult(true);
-            Func<Context, Task<Double>> injectionRate = (ctx) => Task.FromResult(1.01);
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) => Task.FromResult(true);
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) => Task.FromResult(1.01);
             var policy = MonkeyPolicy.InjectFaultAsync(fault, injectionRate, enabled);
 
             Func<Context, Task> actionAsync = (_) => { executed = true; return TaskHelper.EmptyTask; };
@@ -160,8 +160,8 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             Context context = new Context();
 
             Func<Context, CancellationToken, Task<Exception>> fault = (ctx, cts) => Task.FromResult(new Exception());
-            Func<Context, Task<bool>> enabled = (ctx) => Task.FromResult(true);
-            Func<Context, Task<Double>> injectionRate = (ctx) => Task.FromResult(0.6);
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) => Task.FromResult(true);
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) => Task.FromResult(0.6);
             var policy = MonkeyPolicy.InjectFaultAsync(fault, injectionRate, enabled);
 
             Func<Context, Task> actionAsync = (_) => { executed = true; return TaskHelper.EmptyTask; };
@@ -190,7 +190,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(new Exception());
             };
 
-            Func<Context, Task<Double>> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
             {
                 double rate = 0;
                 if (ctx["InjectionRate"] != null)
@@ -201,7 +201,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(rate);
             };
 
-            Func<Context, Task<bool>> enabled = (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
             {
                 return Task.FromResult((bool)ctx["ShouldFail"]);
             };

--- a/src/Polly.Contrib.Simmy.Specs/Fault/InjectFaultTResultAsyncSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Fault/InjectFaultTResultAsyncSpecs.cs
@@ -68,7 +68,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(
                 new Exception(),
                 0.6,
-                async (ctx) =>
+                async (ctx, ct) =>
                 {
                     return await Task.FromResult((bool)ctx["ShouldFail"]);
                 });
@@ -91,7 +91,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(
                 new Exception(),
                 0.4,
-                async (ctx) =>
+                async (ctx, ct) =>
                 {
                     return await Task.FromResult((bool)ctx["ShouldFail"]);
                 });
@@ -116,7 +116,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(
                 new Exception(),
                 0.4,
-                async (ctx) =>
+                async (ctx, ct) =>
                 {
                     return await Task.FromResult((bool)ctx["ShouldFail"]);
                 });
@@ -142,8 +142,8 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             };
 
             Func<Context, CancellationToken, Task<Exception>> fault = (ctx, cts) => Task.FromResult(new Exception());
-            Func<Context, Task<double>> injectionRate = (ctx) => Task.FromResult(0.6);
-            Func<Context, Task<bool>> enabled = (ctx) => Task.FromResult(true);
+            Func<Context, CancellationToken, Task<double>> injectionRate = (ctx, ct) => Task.FromResult(0.6);
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) => Task.FromResult(true);
             var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(fault, injectionRate, enabled);
             policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context))
                 .ShouldThrowExactly<Exception>();
@@ -176,7 +176,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(new Exception());
             };
 
-            Func<Context, Task<Double>> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
             {
                 double rate = 0;
                 if (ctx["InjectionRate"] != null)
@@ -187,7 +187,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(rate);
             };
 
-            Func<Context, Task<bool>> enabled = (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
             {
                 return Task.FromResult((bool)ctx["ShouldFail"]);
             };
@@ -249,7 +249,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             };
 
             ResultPrimitive fault = ResultPrimitive.Fault;
-            Func<Context, Task<bool>> enabled = (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
             {
                 return Task.FromResult((bool)ctx["ShouldFail"]);
             };
@@ -273,7 +273,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             };
 
             ResultPrimitive fault = ResultPrimitive.Fault;
-            Func<Context, Task<bool>> enabled = (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
             {
                 return Task.FromResult((bool)ctx["ShouldFail"]);
             };
@@ -302,7 +302,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(ResultPrimitive.Fault);
             };
 
-            Func<Context, Task<Double>> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
             {
                 double rate = 0;
                 if (ctx["InjectionRate"] != null)
@@ -313,7 +313,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(rate);
             };
 
-            Func<Context, Task<bool>> enabled = (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
             {
                 return Task.FromResult(true);
             };
@@ -342,7 +342,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(ResultPrimitive.Fault);
             };
 
-            Func<Context, Task<Double>> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
             {
                 double rate = 0;
                 if (ctx["InjectionRate"] != null)
@@ -353,7 +353,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 return Task.FromResult(rate);
             };
 
-            Func<Context, Task<bool>> enabled = (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
             {
                 return Task.FromResult(true);
             };

--- a/src/Polly.Contrib.Simmy.Specs/Fault/InjectFaultTResultAsyncSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Fault/InjectFaultTResultAsyncSpecs.cs
@@ -197,6 +197,7 @@ namespace Polly.Contrib.Simmy.Specs.Fault
                 .ShouldThrowExactly<InvalidOperationException>();
             executed.Should().BeFalse();
         }
+
         #endregion
 
         #region TResult Based Monkey Policies
@@ -363,6 +364,226 @@ namespace Polly.Contrib.Simmy.Specs.Fault
             response.Should().Be(ResultPrimitive.Good);
             executed.Should().BeTrue();
         }
+        #endregion
+
+        #region Cancellable scenarios
+
+        [Fact]
+        public void InjectFault_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_before_to_start_execution()
+        {
+            string failureMessage = "Failure Message";
+            Boolean executed = false;
+            Context context = new Context();
+            context["ShouldFail"] = true;
+            context["Message"] = failureMessage;
+            context["InjectionRate"] = 0.6;
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (ctx, ct) =>
+            {
+                executed = true;
+                return Task.FromResult(ResultPrimitive.Good);
+            };
+
+            Func<Context, CancellationToken, Task<Exception>> fault = (ctx, cts) =>
+            {
+                if (ctx["Message"] != null)
+                {
+                    Exception ex = new InvalidOperationException(ctx["Message"].ToString());
+                    return Task.FromResult(ex);
+                }
+
+                return Task.FromResult(new Exception());
+            };
+
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
+            {
+                double rate = 0;
+                if (ctx["InjectionRate"] != null)
+                {
+                    rate = (double)ctx["InjectionRate"];
+                }
+
+                return Task.FromResult(rate);
+            };
+
+            Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
+            {
+                return Task.FromResult((bool)ctx["ShouldFail"]);
+            };
+
+            var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(fault, injectionRate, enabled);
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void InjectFault_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_enabled_config_delegate()
+        {
+            string failureMessage = "Failure Message";
+            Boolean executed = false;
+            Context context = new Context();
+            context["ShouldFail"] = true;
+            context["Message"] = failureMessage;
+            context["InjectionRate"] = 0.6;
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (ctx, ct) =>
+            {
+                executed = true;
+                return Task.FromResult(ResultPrimitive.Good);
+            };
+
+            Func<Context, CancellationToken, Task<Exception>> fault = (ctx, cts) =>
+            {
+                if (ctx["Message"] != null)
+                {
+                    Exception ex = new InvalidOperationException(ctx["Message"].ToString());
+                    return Task.FromResult(ex);
+                }
+
+                return Task.FromResult(new Exception());
+            };
+
+            Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
+            {
+                double rate = 0;
+                if (ctx["InjectionRate"] != null)
+                {
+                    rate = (double)ctx["InjectionRate"];
+                }
+
+                return Task.FromResult(rate);
+            };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
+                {
+                    cts.Cancel();
+                    return Task.FromResult((bool)ctx["ShouldFail"]);
+                };
+
+                var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(fault, injectionRate, enabled);
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void InjectFault_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_injectionrate_config_delegate()
+        {
+            string failureMessage = "Failure Message";
+            Boolean executed = false;
+            Context context = new Context();
+            context["ShouldFail"] = true;
+            context["Message"] = failureMessage;
+            context["InjectionRate"] = 0.6;
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (ctx, ct) =>
+            {
+                executed = true;
+                return Task.FromResult(ResultPrimitive.Good);
+            };
+
+            Func<Context, CancellationToken, Task<Exception>> fault = (ctx, cts) =>
+            {
+                if (ctx["Message"] != null)
+                {
+                    Exception ex = new InvalidOperationException(ctx["Message"].ToString());
+                    return Task.FromResult(ex);
+                }
+
+                return Task.FromResult(new Exception());
+            };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
+                {
+                    return Task.FromResult((bool)ctx["ShouldFail"]);
+                };
+
+                Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
+                {
+                    double rate = 0;
+                    if (ctx["InjectionRate"] != null)
+                    {
+                        rate = (double)ctx["InjectionRate"];
+                    }
+
+                    cts.Cancel();
+                    return Task.FromResult(rate);
+                };
+
+                var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(fault, injectionRate, enabled);
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void InjectFault_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_fault_config_delegate()
+        {
+            string failureMessage = "Failure Message";
+            Boolean executed = false;
+            Context context = new Context();
+            context["ShouldFail"] = true;
+            context["Message"] = failureMessage;
+            context["InjectionRate"] = 0.6;
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (ctx, ct) =>
+            {
+                executed = true;
+                return Task.FromResult(ResultPrimitive.Good);
+            };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, Task<bool>> enabled = (ctx, ct) =>
+                {
+                    return Task.FromResult((bool)ctx["ShouldFail"]);
+                };
+
+                Func<Context, CancellationToken, Task<Double>> injectionRate = (ctx, ct) =>
+                {
+                    double rate = 0;
+                    if (ctx["InjectionRate"] != null)
+                    {
+                        rate = (double)ctx["InjectionRate"];
+                    }
+
+                    return Task.FromResult(rate);
+                };
+
+                Func<Context, CancellationToken, Task<Exception>> fault = (ctx, ct) =>
+                {
+                    cts.Cancel();
+                    if (ctx["Message"] != null)
+                    {
+                        Exception ex = new InvalidOperationException(ctx["Message"].ToString());
+                        return Task.FromResult(ex);
+                    }
+
+                    return Task.FromResult(new Exception());
+                };
+
+                var policy = MonkeyPolicy.InjectFaultAsync<ResultPrimitive>(fault, injectionRate, enabled);
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+        }
+
         #endregion
     }
 }

--- a/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyAsyncSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyAsyncSpecs.cs
@@ -94,7 +94,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = true;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
@@ -116,7 +116,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = false;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
@@ -138,7 +138,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = true;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
@@ -161,12 +161,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.6;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -194,12 +194,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.3;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -238,12 +238,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return await Task.FromResult(TimeSpan.FromMilliseconds(0));
             };
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -282,12 +282,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return await Task.FromResult(TimeSpan.FromMilliseconds(0));
             };
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -326,12 +326,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return await Task.FromResult(TimeSpan.FromMilliseconds(0));
             };
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {

--- a/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyTResultAsyncSpecs .cs
+++ b/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyTResultAsyncSpecs .cs
@@ -99,7 +99,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = true;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
@@ -122,7 +122,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = false;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
@@ -145,7 +145,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = true;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
@@ -169,12 +169,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.6;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -203,12 +203,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.3;
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -248,12 +248,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return await Task.FromResult(TimeSpan.FromMilliseconds(0));
             };
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -293,12 +293,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return await Task.FromResult(TimeSpan.FromMilliseconds(0));
             };
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -338,12 +338,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return await Task.FromResult(TimeSpan.FromMilliseconds(0));
             };
 
-            Func<Context, Task<bool>> enabled = async (ctx) =>
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
             {
                 return await Task.FromResult((bool)ctx["Enabled"]);
             };
 
-            Func<Context, Task<double>> injectionRate = async (ctx) =>
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {

--- a/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyTResultAsyncSpecs .cs
+++ b/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyTResultAsyncSpecs .cs
@@ -365,5 +365,211 @@ namespace Polly.Contrib.Simmy.Specs.Latency
         }
 
         #endregion
+
+        #region Cancellable scenarios
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_before_to_start_execution()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Func<Context, CancellationToken, Task<TimeSpan>> latencyProvider = async (ctx, ct) =>
+            {
+                if ((bool)ctx["ShouldInjectLatency"])
+                {
+                    return await Task.FromResult(delay);
+                }
+
+                return await Task.FromResult(TimeSpan.FromMilliseconds(0));
+            };
+
+            Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
+            {
+                return await Task.FromResult((bool)ctx["Enabled"]);
+            };
+
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
+            {
+                if (ctx["InjectionRate"] != null)
+                {
+                    return await Task.FromResult((double)ctx["InjectionRate"]);
+                }
+
+                return await Task.FromResult(0);
+            };
+
+            Boolean executed = false;
+            var policy = MonkeyPolicy.InjectLatencyAsync<ResultPrimitive>(latencyProvider, injectionRate, enabled);
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (_, ct) => { executed = true; return Task.FromResult(ResultPrimitive.Good); };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_enabled_config_delegate()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Func<Context, CancellationToken, Task<TimeSpan>> latencyProvider = async (ctx, ct) =>
+            {
+                if ((bool)ctx["ShouldInjectLatency"])
+                {
+                    return await Task.FromResult(delay);
+                }
+
+                return await Task.FromResult(TimeSpan.FromMilliseconds(0));
+            };
+
+            Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
+            {
+                if (ctx["InjectionRate"] != null)
+                {
+                    return await Task.FromResult((double)ctx["InjectionRate"]);
+                }
+
+                return await Task.FromResult(0);
+            };
+
+            Boolean executed = false;
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (_, ct) => { executed = true; return Task.FromResult(ResultPrimitive.Good); };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
+                {
+                    cts.Cancel();
+                    return await Task.FromResult((bool)ctx["Enabled"]);
+                };
+
+                var policy = MonkeyPolicy.InjectLatencyAsync<ResultPrimitive>(latencyProvider, injectionRate, enabled);
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_injectionrate_config_delegate()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Func<Context, CancellationToken, Task<TimeSpan>> latencyProvider = async (ctx, ct) =>
+            {
+                if ((bool)ctx["ShouldInjectLatency"])
+                {
+                    return await Task.FromResult(delay);
+                }
+
+                return await Task.FromResult(TimeSpan.FromMilliseconds(0));
+            };
+
+            Boolean executed = false;
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (_, ct) => { executed = true; return Task.FromResult(ResultPrimitive.Good); };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
+                {
+                    return await Task.FromResult((bool)ctx["Enabled"]);
+                };
+
+                Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
+                {
+                    cts.Cancel();
+
+                    if (ctx["InjectionRate"] != null)
+                    {
+                        return await Task.FromResult((double)ctx["InjectionRate"]);
+                    }
+
+                    return await Task.FromResult(0);
+                };
+
+                var policy = MonkeyPolicy.InjectLatencyAsync<ResultPrimitive>(latencyProvider, injectionRate, enabled);
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_latency_config_delegate()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Boolean executed = false;
+            Func<Context, CancellationToken, Task<ResultPrimitive>> actionAsync = (_, ct) => { executed = true; return Task.FromResult(ResultPrimitive.Good); };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, Task<bool>> enabled = async (ctx, ct) =>
+                {
+                    return await Task.FromResult((bool)ctx["Enabled"]);
+                };
+
+                Func<Context, CancellationToken, Task<double>> injectionRate = async (ctx, ct) =>
+                {
+                    if (ctx["InjectionRate"] != null)
+                    {
+                        return await Task.FromResult((double)ctx["InjectionRate"]);
+                    }
+
+                    return await Task.FromResult(0);
+                };
+
+                Func<Context, CancellationToken, Task<TimeSpan>> latencyProvider = async (ctx, ct) =>
+                {
+                    cts.Cancel();
+
+                    if ((bool)ctx["ShouldInjectLatency"])
+                    {
+                        return await Task.FromResult(delay);
+                    }
+
+                    return await Task.FromResult(TimeSpan.FromMilliseconds(0));
+                };
+
+                var policy = MonkeyPolicy.InjectLatencyAsync<ResultPrimitive>(latencyProvider, injectionRate, enabled);
+
+                policy.Awaiting(async x => await x.ExecuteAsync(actionAsync, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        #endregion
     }
 }

--- a/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyTResultSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Latency/InjectLatencyTResultSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using FluentAssertions;
 using Polly.Utilities;
 using Polly.Contrib.Simmy.Specs.Helpers;
@@ -97,7 +98,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = true;
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
@@ -120,7 +121,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = false;
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
@@ -143,7 +144,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var context = new Context();
             context["Enabled"] = true;
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
@@ -167,12 +168,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.6;
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
 
-            Func<Context, double> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -201,12 +202,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.3;
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
 
-            Func<Context, double> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -236,7 +237,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.6;
 
-            Func<Context, TimeSpan> latencyProvider = (ctx) =>
+            Func<Context, CancellationToken, TimeSpan> latencyProvider = (ctx, ct) =>
             {
                 if ((bool)ctx["ShouldInjectLatency"])
                 {
@@ -246,12 +247,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return TimeSpan.FromMilliseconds(0);
             };
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
 
-            Func<Context, double> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -281,7 +282,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.6;
 
-            Func<Context, TimeSpan> latencyProvider = (ctx) =>
+            Func<Context, CancellationToken, TimeSpan> latencyProvider = (ctx, ct) =>
             {
                 if ((bool)ctx["ShouldInjectLatency"])
                 {
@@ -291,12 +292,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return TimeSpan.FromMilliseconds(0);
             };
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
 
-            Func<Context, double> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -326,7 +327,7 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             context["Enabled"] = true;
             context["InjectionRate"] = 0.3;
 
-            Func<Context, TimeSpan> latencyProvider = (ctx) =>
+            Func<Context, CancellationToken, TimeSpan> latencyProvider = (ctx, ct) =>
             {
                 if ((bool)ctx["ShouldInjectLatency"])
                 {
@@ -336,12 +337,12 @@ namespace Polly.Contrib.Simmy.Specs.Latency
                 return TimeSpan.FromMilliseconds(0);
             };
 
-            Func<Context, bool> enabled = (ctx) =>
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
             {
                 return ((bool)ctx["Enabled"]);
             };
 
-            Func<Context, double> injectionRate = (ctx) =>
+            Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
             {
                 if (ctx["InjectionRate"] != null)
                 {
@@ -358,6 +359,210 @@ namespace Polly.Contrib.Simmy.Specs.Latency
             var result = policy.Execute(action, context);
 
             executed.Should().BeTrue();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        #endregion
+
+        #region Cancellable scenarios
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_before_to_start_execution()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Func<Context, CancellationToken, TimeSpan> latencyProvider = (ctx, ct) =>
+            {
+                if ((bool)ctx["ShouldInjectLatency"])
+                {
+                    return delay;
+                }
+
+                return TimeSpan.FromMilliseconds(0);
+            };
+
+            Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
+            {
+                return (bool)ctx["Enabled"];
+            };
+
+            Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
+            {
+                if (ctx["InjectionRate"] != null)
+                {
+                    return (double)ctx["InjectionRate"];
+                }
+
+                return 0;
+            };
+
+            Boolean executed = false;
+            Func<Context, CancellationToken, ResultPrimitive> action = (ctx, ct) => { executed = true; return ResultPrimitive.Good; };
+            var policy = MonkeyPolicy.InjectLatency(latencyProvider, injectionRate, enabled);
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                policy.Invoking(x => x.Execute(action, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_enabled_config_delegate()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Func<Context, CancellationToken, TimeSpan> latencyProvider = (ctx, ct) =>
+            {
+                if ((bool)ctx["ShouldInjectLatency"])
+                {
+                    return delay;
+                }
+
+                return TimeSpan.FromMilliseconds(0);
+            };
+
+            Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
+            {
+                if (ctx["InjectionRate"] != null)
+                {
+                    return (double)ctx["InjectionRate"];
+                }
+
+                return 0;
+            };
+
+            Boolean executed = false;
+            Func<Context, CancellationToken, ResultPrimitive> action = (ctx, ct) => { executed = true; return ResultPrimitive.Good; };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
+                {
+                    cts.Cancel();
+                    return (bool)ctx["Enabled"];
+                };
+
+                var policy = MonkeyPolicy.InjectLatency(latencyProvider, injectionRate, enabled);
+                policy.Invoking(x => x.Execute(action, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_injectionrate_config_delegate()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Func<Context, CancellationToken, TimeSpan> latencyProvider = (ctx, ct) =>
+            {
+                if ((bool)ctx["ShouldInjectLatency"])
+                {
+                    return delay;
+                }
+
+                return TimeSpan.FromMilliseconds(0);
+            };
+
+            Boolean executed = false;
+            Func<Context, CancellationToken, ResultPrimitive> action = (ctx, ct) => { executed = true; return ResultPrimitive.Good; };
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
+                {
+                    return (bool)ctx["Enabled"];
+                };
+
+                Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
+                {
+                    cts.Cancel();
+
+                    if (ctx["InjectionRate"] != null)
+                    {
+                        return (double)ctx["InjectionRate"];
+                    }
+
+                    return 0;
+                };
+
+                var policy = MonkeyPolicy.InjectLatency(latencyProvider, injectionRate, enabled);
+
+                policy.Invoking(x => x.Execute(action, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+            _totalTimeSlept.Should().Be(0);
+        }
+
+        [Fact]
+        public void InjectLatency_With_Context_Should_not_execute_user_delegate_if_user_cancelationtoken_cancelled_on_latency_config_delegate()
+        {
+            var delay = TimeSpan.FromMilliseconds(500);
+            var context = new Context();
+            context["ShouldInjectLatency"] = true;
+            context["Enabled"] = true;
+            context["InjectionRate"] = 0.6;
+
+            Boolean executed = false;
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Func<Context, CancellationToken, bool> enabled = (ctx, ct) =>
+                {
+                    return (bool)ctx["Enabled"];
+                };
+
+                Func<Context, CancellationToken, double> injectionRate = (ctx, ct) =>
+                {
+                    if (ctx["InjectionRate"] != null)
+                    {
+                        return (double)ctx["InjectionRate"];
+                    }
+
+                    return 0;
+                };
+
+                Func<Context, CancellationToken, TimeSpan> latencyProvider = (ctx, ct) =>
+                {
+                    cts.Cancel();
+
+                    if ((bool)ctx["ShouldInjectLatency"])
+                    {
+                        return delay;
+                    }
+
+                    return TimeSpan.FromMilliseconds(0);
+                };
+
+                var policy = MonkeyPolicy.InjectLatency(latencyProvider, injectionRate, enabled);
+                Func<Context, CancellationToken, ResultPrimitive> action = (ctx, ct) => { executed = true; return ResultPrimitive.Good; };
+
+                policy.Invoking(x => x.Execute(action, context, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
             _totalTimeSlept.Should().Be(0);
         }
 

--- a/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs
+++ b/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs
@@ -14,7 +14,7 @@ namespace Polly.Contrib.Simmy
             Func<Context, CancellationToken, Task<bool>> enabled, 
             bool continueOnCapturedContext)
         {
-            // to prevent execute config delegates if user cancels the whole execution before to start.
+            // to prevent execute config delegates if token is signaled before to start.
             cancellationToken.ThrowIfCancellationRequested();
 
             if (!await enabled(context, cancellationToken).ConfigureAwait(continueOnCapturedContext))
@@ -22,12 +22,12 @@ namespace Polly.Contrib.Simmy
                 return false;
             }
 
-            // to prevent execute injectionRate config delegate if user cancels execution on enable configuration delegate.
+            // to prevent execute injectionRate config delegate if token is signaled on enable configuration delegate.
             cancellationToken.ThrowIfCancellationRequested();
 
             double injectionThreshold = await injectionRate(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
 
-            // to prevent execute further config delegates if user cancels execution on injectionRate configuration delegate.
+            // to prevent execute further config delegates if token is signaled on injectionRate configuration delegate.
             cancellationToken.ThrowIfCancellationRequested();
 
             if (injectionThreshold < 0)
@@ -56,7 +56,7 @@ namespace Polly.Contrib.Simmy
                 await injectedBehaviour(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
             }
 
-            // to prevent execute the user's action if user cancels execution on injectedBehaviour configuration delegate.
+            // to prevent execute the user's action if token is signaled on injectedBehaviour delegate.
             cancellationToken.ThrowIfCancellationRequested();
             return await action(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
         }
@@ -74,7 +74,7 @@ namespace Polly.Contrib.Simmy
             {
                 Exception exception = await injectedException(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
 
-                // to prevent throws the exception if user cancels execution on injectedException configuration delegate.
+                // to prevent throws the exception if token is signaled on injectedException configuration delegate.
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (exception != null)
@@ -100,6 +100,8 @@ namespace Polly.Contrib.Simmy
                 return await injectedResult(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
             }
 
+            // to prevent inject the result if token is signaled on injectedResult delegate.
+            cancellationToken.ThrowIfCancellationRequested();
             return await action(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
         }
     }

--- a/src/Polly.Contrib.Simmy/AsyncMonkeyPolicy.cs
+++ b/src/Polly.Contrib.Simmy/AsyncMonkeyPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Polly.Contrib.Simmy
@@ -8,10 +9,10 @@ namespace Polly.Contrib.Simmy
     /// </summary>
     public abstract class AsyncMonkeyPolicy : AsyncPolicy, IMonkeyPolicy
     {
-        internal Func<Context, Task<Double>> InjectionRate { get; }
-        internal Func<Context, Task<bool>> Enabled { get; }
+        internal Func<Context, CancellationToken, Task<Double>> InjectionRate { get; }
+        internal Func<Context, CancellationToken, Task<bool>> Enabled { get; }
 
-        internal AsyncMonkeyPolicy(Func<Context, Task<Double>> injectionRate, Func<Context, Task<bool>> enabled)
+        internal AsyncMonkeyPolicy(Func<Context, CancellationToken, Task<Double>> injectionRate, Func<Context, CancellationToken, Task<bool>> enabled)
         {
             InjectionRate = injectionRate ?? throw new ArgumentNullException(nameof(injectionRate));
             Enabled = enabled ?? throw new ArgumentNullException(nameof(enabled));
@@ -24,10 +25,10 @@ namespace Polly.Contrib.Simmy
     /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
     public abstract class AsyncMonkeyPolicy<TResult> : AsyncPolicy<TResult>, IMonkeyPolicy<TResult>
     {
-        internal Func<Context, Task<Double>> InjectionRate { get; }
-        internal Func<Context, Task<bool>> Enabled { get; }
+        internal Func<Context, CancellationToken, Task<Double>> InjectionRate { get; }
+        internal Func<Context, CancellationToken, Task<bool>> Enabled { get; }
 
-        internal AsyncMonkeyPolicy(Func<Context, Task<Double>> injectionRate, Func<Context, Task<bool>> enabled) 
+        internal AsyncMonkeyPolicy(Func<Context, CancellationToken, Task<Double>> injectionRate, Func<Context, CancellationToken, Task<bool>> enabled) 
         {
             InjectionRate = injectionRate ?? throw new ArgumentNullException(nameof(injectionRate));
             Enabled = enabled ?? throw new ArgumentNullException(nameof(enabled));

--- a/src/Polly.Contrib.Simmy/Behavior/AsyncInjectBehaviourPolicy.cs
+++ b/src/Polly.Contrib.Simmy/Behavior/AsyncInjectBehaviourPolicy.cs
@@ -11,7 +11,7 @@ namespace Polly.Contrib.Simmy.Behavior
     {
         private readonly Func<Context, CancellationToken, Task> _behaviour;
 
-        internal AsyncInjectBehaviourPolicy(Func<Context, CancellationToken, Task> behaviour, Func<Context, Task<Double>> injectionRate, Func<Context, Task<bool>> enabled)
+        internal AsyncInjectBehaviourPolicy(Func<Context, CancellationToken, Task> behaviour, Func<Context, CancellationToken, Task<Double>> injectionRate, Func<Context, CancellationToken, Task<bool>> enabled)
             : base(injectionRate, enabled)
         {
             _behaviour = behaviour ?? throw new ArgumentNullException(nameof(behaviour));
@@ -40,7 +40,7 @@ namespace Polly.Contrib.Simmy.Behavior
     {
         private readonly Func<Context, CancellationToken, Task> _behaviour;
 
-        internal AsyncInjectBehaviourPolicy(Func<Context, CancellationToken, Task> behaviour, Func<Context, Task<Double>> injectionRate, Func<Context, Task<bool>> enabled)
+        internal AsyncInjectBehaviourPolicy(Func<Context, CancellationToken, Task> behaviour, Func<Context, CancellationToken, Task<Double>> injectionRate, Func<Context, CancellationToken, Task<bool>> enabled)
             : base(injectionRate, enabled)
         {
             _behaviour = behaviour ?? throw new ArgumentNullException(nameof(behaviour));

--- a/src/Polly.Contrib.Simmy/Behavior/AsyncInjectBehaviourSyntax.cs
+++ b/src/Polly.Contrib.Simmy/Behavior/AsyncInjectBehaviourSyntax.cs
@@ -27,8 +27,8 @@ namespace Polly.Contrib.Simmy
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task BehaviourLambda(Context _, CancellationToken __) => behaviour();
-            Task<Double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
-            Task<bool> EnabledLambda(Context _) => enabled();
+            Task<Double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviourAsync(BehaviourLambda, InjectionRateLambda, EnabledLambda);
         }
@@ -49,8 +49,8 @@ namespace Polly.Contrib.Simmy
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Task<Double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
-            Task<bool> EnabledLambda(Context _) => enabled();
+            Task<Double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviourAsync(behaviour, InjectionRateLambda, EnabledLambda);
         }
@@ -66,12 +66,12 @@ namespace Polly.Contrib.Simmy
         public static AsyncInjectBehaviourPolicy InjectBehaviourAsync(
             Func<Context, CancellationToken, Task> behaviour,
             Double injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Task<Double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
+            Task<Double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
 
             return InjectBehaviourAsync(behaviour, InjectionRateLambda, enabled);
         }
@@ -86,8 +86,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectBehaviourPolicy InjectBehaviourAsync(
             Func<Context, CancellationToken, Task> behaviour,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/Behavior/AsyncInjectBehaviourTResultSyntax.cs
+++ b/src/Polly.Contrib.Simmy/Behavior/AsyncInjectBehaviourTResultSyntax.cs
@@ -27,8 +27,8 @@ namespace Polly.Contrib.Simmy
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task BehaviourLambda(Context _, CancellationToken __) => behaviour();
-            Task<Double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
-            Task<bool> EnabledLambda(Context _) => enabled();
+            Task<Double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviourAsync<TResult>(BehaviourLambda, InjectionRateLambda, EnabledLambda);
         }
@@ -49,8 +49,8 @@ namespace Polly.Contrib.Simmy
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Task<Double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
-            Task<bool> EnabledLambda(Context _) => enabled();
+            Task<Double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviourAsync<TResult>(behaviour, InjectionRateLambda, EnabledLambda);
         }
@@ -66,12 +66,12 @@ namespace Polly.Contrib.Simmy
         public static AsyncInjectBehaviourPolicy<TResult> InjectBehaviourAsync<TResult>(
             Func<Context, CancellationToken, Task> behaviour,
             Double injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Task<Double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
+            Task<Double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
 
             return InjectBehaviourAsync<TResult>(behaviour, InjectionRateLambda, enabled);
         }
@@ -86,8 +86,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectBehaviourPolicy<TResult> InjectBehaviourAsync<TResult>(
             Func<Context, CancellationToken, Task> behaviour,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/Behavior/InjectBehaviourPolicy.cs
+++ b/src/Polly.Contrib.Simmy/Behavior/InjectBehaviourPolicy.cs
@@ -8,9 +8,9 @@ namespace Polly.Contrib.Simmy.Behavior
     /// </summary>
     public class InjectBehaviourPolicy : Simmy.MonkeyPolicy
     {
-        private readonly Action<Context> _behaviour;
+        private readonly Action<Context, CancellationToken> _behaviour;
 
-        internal InjectBehaviourPolicy(Action<Context> behaviour, Func<Context, double> injectionRate, Func<Context, bool> enabled) 
+        internal InjectBehaviourPolicy(Action<Context, CancellationToken> behaviour, Func<Context, CancellationToken, double> injectionRate, Func<Context, CancellationToken, bool> enabled) 
             : base(injectionRate, enabled)
         {
             _behaviour = behaviour ?? throw new ArgumentNullException(nameof(behaviour));
@@ -23,7 +23,7 @@ namespace Polly.Contrib.Simmy.Behavior
                 action,
                 context,
                 cancellationToken,
-                (ctx, ct) => _behaviour(ctx),
+                (ctx, ct) => _behaviour(ctx, ct),
                 InjectionRate,
                 Enabled);
         }
@@ -34,8 +34,8 @@ namespace Polly.Contrib.Simmy.Behavior
     /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
     public class InjectBehaviourPolicy<TResult> : MonkeyPolicy<TResult>
     {
-        private readonly Action<Context> _behaviour;
-        internal InjectBehaviourPolicy(Action<Context> behaviour, Func<Context, double> injectionRate, Func<Context, bool> enabled)
+        private readonly Action<Context, CancellationToken> _behaviour;
+        internal InjectBehaviourPolicy(Action<Context, CancellationToken> behaviour, Func<Context, CancellationToken, double> injectionRate, Func<Context, CancellationToken, bool> enabled)
             : base(injectionRate, enabled)
         {
             _behaviour = behaviour ?? throw new ArgumentNullException(nameof(behaviour));
@@ -48,7 +48,7 @@ namespace Polly.Contrib.Simmy.Behavior
                 action,
                 context,
                 cancellationToken,
-                (ctx, ct) => _behaviour(ctx),
+                (ctx, ct) => _behaviour(ctx, ct),
                 InjectionRate,
                 Enabled);
         }

--- a/src/Polly.Contrib.Simmy/Behavior/InjectBehaviourSyntax.cs
+++ b/src/Polly.Contrib.Simmy/Behavior/InjectBehaviourSyntax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Polly.Contrib.Simmy.Behavior;
 
 namespace Polly.Contrib.Simmy
@@ -24,9 +25,9 @@ namespace Polly.Contrib.Simmy
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            void BehaviourLambda(Context _) => behaviour();
-            double InjectionRateLambda(Context _) => injectionRate;
-            bool EnabledLambda(Context _) => enabled();
+            void BehaviourLambda(Context _, CancellationToken __) => behaviour();
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            bool EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviour(BehaviourLambda, InjectionRateLambda, EnabledLambda);
         }
@@ -40,15 +41,15 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in context free mode</param>
         /// <returns>The policy instance.</returns>
         public static InjectBehaviourPolicy InjectBehaviour(
-            Action<Context> behaviour,
+            Action<Context, CancellationToken> behaviour,
             Double injectionRate,
             Func<bool> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            double InjectionRateLambda(Context _) => injectionRate;
-            bool EnabledLambda(Context _) => enabled();
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            bool EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviour(behaviour, InjectionRateLambda, EnabledLambda);
         }
@@ -62,15 +63,15 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectBehaviourPolicy InjectBehaviour(
-            Action<Context> behaviour,
+            Action<Context, CancellationToken> behaviour,
             Double injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            double InjectionRateLambda(Context _) => injectionRate;
-            return InjectBehaviour(behaviour, (Func<Context, Double>) InjectionRateLambda, enabled);
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            return InjectBehaviour(behaviour, (Func<Context, CancellationToken, Double>)InjectionRateLambda, enabled);
         }
 
         /// <summary>
@@ -82,9 +83,9 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectBehaviourPolicy InjectBehaviour(
-            Action<Context> behaviour,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Action<Context, CancellationToken> behaviour,
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/Behavior/InjectBehaviourTResultSyntax.cs
+++ b/src/Polly.Contrib.Simmy/Behavior/InjectBehaviourTResultSyntax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Polly.Contrib.Simmy.Behavior;
 
 namespace Polly.Contrib.Simmy
@@ -24,9 +25,9 @@ namespace Polly.Contrib.Simmy
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            void BehaviourLambda(Context _) => behaviour();
-            double InjectionRateLambda(Context _) => injectionRate;
-            bool EnabledLambda(Context _) => enabled();
+            void BehaviourLambda(Context _, CancellationToken __) => behaviour();
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            bool EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviour<TResult>(BehaviourLambda, InjectionRateLambda, EnabledLambda);
         }
@@ -40,15 +41,15 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in context free mode</param>
         /// <returns>The policy instance.</returns>
         public static InjectBehaviourPolicy<TResult> InjectBehaviour<TResult>(
-            Action<Context> behaviour,
+            Action<Context, CancellationToken> behaviour,
             Double injectionRate,
             Func<bool> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            double InjectionRateLambda(Context _) => injectionRate;
-            bool EnabledLambda(Context _) => enabled();
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            bool EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return InjectBehaviour<TResult>(behaviour, InjectionRateLambda, EnabledLambda);
         }
@@ -62,14 +63,14 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectBehaviourPolicy<TResult> InjectBehaviour<TResult>(
-            Action<Context> behaviour,
+            Action<Context, CancellationToken> behaviour,
             Double injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            double InjectionRateLambda(Context _) => injectionRate;
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
             return InjectBehaviour<TResult>(behaviour, InjectionRateLambda, enabled);
         }
 
@@ -82,9 +83,9 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectBehaviourPolicy<TResult> InjectBehaviour<TResult>(
-            Action<Context> behaviour,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Action<Context, CancellationToken> behaviour,
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (behaviour == null) throw new ArgumentNullException(nameof(behaviour));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/Fault/AsyncInjectFaultSyntax.cs
+++ b/src/Polly.Contrib.Simmy/Fault/AsyncInjectFaultSyntax.cs
@@ -23,8 +23,8 @@ namespace Polly.Contrib.Simmy
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<Exception> FaultLambda(Context _, CancellationToken __) => Task.FromResult<Exception>(fault);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult<Double>(injectionRate);
-            Task<bool> EnabledLambda(Context _) => Task.FromResult<bool>(enabled());
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult<Double>(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => Task.FromResult<bool>(enabled());
 
             return new AsyncInjectOutcomePolicy(FaultLambda, InjectionRateLambda, EnabledLambda);
         }
@@ -40,12 +40,12 @@ namespace Polly.Contrib.Simmy
         public static AsyncInjectOutcomePolicy InjectFaultAsync(
             Exception fault,
             Double injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<Exception> FaultLambda(Context _, CancellationToken __) => Task.FromResult<Exception>(fault);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult<Double>(injectionRate);
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult<Double>(injectionRate);
 
             return new AsyncInjectOutcomePolicy(FaultLambda, InjectionRateLambda, enabled);
         }
@@ -60,8 +60,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectOutcomePolicy InjectFaultAsync(
             Func<Context, CancellationToken, Task<Exception>> faultProvider,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (faultProvider == null) throw new ArgumentNullException(nameof(faultProvider));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
@@ -90,8 +90,8 @@ namespace Polly.Contrib.Simmy
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<Exception> FaultLambda(Context _, CancellationToken __) => Task.FromResult<Exception>(fault);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult<Double>(injectionRate);
-            Task<bool> EnabledLambda(Context _) => Task.FromResult<bool>(enabled());
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult<Double>(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => Task.FromResult<bool>(enabled());
 
             return new AsyncInjectOutcomePolicy<TResult>((Func<Context, CancellationToken, Task<Exception>>)FaultLambda, InjectionRateLambda, EnabledLambda);
         }
@@ -107,12 +107,12 @@ namespace Polly.Contrib.Simmy
         public static AsyncInjectOutcomePolicy<TResult> InjectFaultAsync<TResult>(
             Exception fault,
             Double injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<Exception> FaultLambda(Context _, CancellationToken __) => Task.FromResult<Exception>(fault);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult<Double>(injectionRate);
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult<Double>(injectionRate);
 
             return new AsyncInjectOutcomePolicy<TResult>((Func<Context, CancellationToken, Task<Exception>>)FaultLambda, InjectionRateLambda, enabled);
         }
@@ -127,8 +127,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectOutcomePolicy<TResult> InjectFaultAsync<TResult>(
             Func<Context, CancellationToken, Task<Exception>> faultProvider,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (faultProvider == null) throw new ArgumentNullException(nameof(faultProvider));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
@@ -156,8 +156,8 @@ namespace Polly.Contrib.Simmy
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<TResult> FaultLambda(Context _, CancellationToken __) => Task.FromResult<TResult>(fault);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult<Double>(injectionRate);
-            Task<bool> EnabledLambda(Context _)
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult<Double>(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __)
             {
                 return Task.FromResult<bool>(enabled());
             }
@@ -176,12 +176,12 @@ namespace Polly.Contrib.Simmy
         public static AsyncInjectOutcomePolicy<TResult> InjectFaultAsync<TResult>(
             TResult fault,
             Double injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<TResult> FaultLambda(Context _, CancellationToken __) => Task.FromResult<TResult>(fault);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult<Double>(injectionRate);
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult<Double>(injectionRate);
 
             return new AsyncInjectOutcomePolicy<TResult>((Func<Context, CancellationToken, Task<TResult>>)FaultLambda, InjectionRateLambda, enabled);
         }
@@ -196,8 +196,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectOutcomePolicy<TResult> InjectFaultAsync<TResult>(
             Func<Context, CancellationToken, Task<TResult>> fault,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (fault == null) throw new ArgumentNullException(nameof(fault));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/Fault/AsyncInjectOutcomePolicy.cs
+++ b/src/Polly.Contrib.Simmy/Fault/AsyncInjectOutcomePolicy.cs
@@ -12,7 +12,7 @@ namespace Polly.Contrib.Simmy.Fault
     {
         private readonly Func<Context, CancellationToken, Task<Exception>> _faultProvider;
 
-        internal AsyncInjectOutcomePolicy(Func<Context, CancellationToken, Task<Exception>> faultProvider, Func<Context, Task<Double>> injectionRate, Func<Context, Task<bool>> enabled)
+        internal AsyncInjectOutcomePolicy(Func<Context, CancellationToken, Task<Exception>> faultProvider, Func<Context, CancellationToken, Task<Double>> injectionRate, Func<Context, CancellationToken, Task<bool>> enabled)
             : base(injectionRate, enabled)
         {
             _faultProvider = faultProvider ?? throw new ArgumentNullException(nameof(faultProvider));
@@ -41,13 +41,13 @@ namespace Polly.Contrib.Simmy.Fault
         private readonly Func<Context, CancellationToken, Task<Exception>> _faultProvider;
         private readonly Func<Context, CancellationToken, Task<TResult>> _resultProvider;
 
-        internal AsyncInjectOutcomePolicy(Func<Context, CancellationToken, Task<Exception>> faultProvider, Func<Context, Task<Double>> injectionRate, Func<Context, Task<bool>> enabled)
+        internal AsyncInjectOutcomePolicy(Func<Context, CancellationToken, Task<Exception>> faultProvider, Func<Context, CancellationToken, Task<Double>> injectionRate, Func<Context, CancellationToken, Task<bool>> enabled)
             : base(injectionRate, enabled)
         {
             _faultProvider = faultProvider ?? throw new ArgumentNullException(nameof(faultProvider));
         }
 
-        internal AsyncInjectOutcomePolicy(Func<Context, CancellationToken, Task<TResult>> resultProvider, Func<Context, Task<Double>> injectionRate, Func<Context, Task<bool>> enabled)
+        internal AsyncInjectOutcomePolicy(Func<Context, CancellationToken, Task<TResult>> resultProvider, Func<Context, CancellationToken, Task<Double>> injectionRate, Func<Context, CancellationToken, Task<bool>> enabled)
             : base(injectionRate, enabled)
         {
             _resultProvider = resultProvider ?? throw new ArgumentNullException(nameof(resultProvider));

--- a/src/Polly.Contrib.Simmy/Fault/InjectFaultSyntax.cs
+++ b/src/Polly.Contrib.Simmy/Fault/InjectFaultSyntax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Polly.Contrib.Simmy.Fault;
 
 namespace Polly.Contrib.Simmy
@@ -20,9 +21,9 @@ namespace Polly.Contrib.Simmy
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Exception FaultLambda(Context _) => fault;
-            double InjectionRateLambda(Context _) => injectionRate;
-            bool EnabledLambda(Context _) => enabled();
+            Exception FaultLambda(Context _, CancellationToken __) => fault;
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            bool EnabledLambda(Context _, CancellationToken __) => enabled();
 
             return new InjectOutcomePolicy(FaultLambda, InjectionRateLambda, EnabledLambda);
         }
@@ -38,12 +39,12 @@ namespace Polly.Contrib.Simmy
         public static InjectOutcomePolicy InjectFault(
             Exception fault,
             Double injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Exception FaultLambda(Context _) => fault;
-            double InjectionRateLambda(Context _) => injectionRate;
+            Exception FaultLambda(Context _, CancellationToken __) => fault;
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
 
             return new InjectOutcomePolicy(FaultLambda, InjectionRateLambda, enabled);
         }
@@ -57,9 +58,9 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectOutcomePolicy InjectFault(
-            Func<Context, Exception> faultProvider,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, Exception> faultProvider,
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (faultProvider == null) throw new ArgumentNullException(nameof(faultProvider));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
@@ -87,11 +88,11 @@ namespace Polly.Contrib.Simmy
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Exception FaultLambda(Context _) => fault;
-            double InjectionRateLambda(Context _) => injectionRate;
-            bool EnabledLambda(Context _) => enabled();
+            Exception FaultLambda(Context _, CancellationToken __) => fault;
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            bool EnabledLambda(Context _, CancellationToken __) => enabled();
 
-            return new InjectOutcomePolicy<TResult>((Func<Context, Exception>)FaultLambda, InjectionRateLambda, EnabledLambda);
+            return new InjectOutcomePolicy<TResult>((Func<Context, CancellationToken, Exception>)FaultLambda, InjectionRateLambda, EnabledLambda);
         }
 
         /// <summary>
@@ -105,14 +106,14 @@ namespace Polly.Contrib.Simmy
         public static InjectOutcomePolicy<TResult> InjectFault<TResult>(
             Exception fault,
             Double injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            Exception FaultLambda(Context _) => fault;
-            double InjectionRateLambda(Context _) => injectionRate;
+            Exception FaultLambda(Context _, CancellationToken __) => fault;
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
 
-            return new InjectOutcomePolicy<TResult>((Func<Context, Exception>)FaultLambda, InjectionRateLambda, enabled);
+            return new InjectOutcomePolicy<TResult>((Func<Context, CancellationToken, Exception>)FaultLambda, InjectionRateLambda, enabled);
         }
 
         /// <summary>
@@ -124,9 +125,9 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectOutcomePolicy<TResult> InjectFault<TResult>(
-            Func<Context, Exception> faultProvider,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, Exception> faultProvider,
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (faultProvider == null) throw new ArgumentNullException(nameof(faultProvider));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
@@ -154,11 +155,11 @@ namespace Polly.Contrib.Simmy
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            TResult FaultLambda(Context _) => fault;
-            double InjectionRateLambda(Context _) => injectionRate;
-            bool EnabledLambda(Context _) => enabled();
+            TResult FaultLambda(Context _, CancellationToken __) => fault;
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
+            bool EnabledLambda(Context _, CancellationToken __) => enabled();
 
-            return new InjectOutcomePolicy<TResult>((Func<Context, TResult>)FaultLambda, InjectionRateLambda, EnabledLambda);
+            return new InjectOutcomePolicy<TResult>((Func<Context, CancellationToken, TResult>)FaultLambda, InjectionRateLambda, EnabledLambda);
         }
 
         /// <summary>
@@ -172,14 +173,14 @@ namespace Polly.Contrib.Simmy
         public static InjectOutcomePolicy<TResult> InjectFault<TResult>(
             TResult fault,
             Double injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            TResult FaultLambda(Context _) => fault;
-            double InjectionRateLambda(Context _) => injectionRate;
+            TResult FaultLambda(Context _, CancellationToken __) => fault;
+            double InjectionRateLambda(Context _, CancellationToken __) => injectionRate;
 
-            return new InjectOutcomePolicy<TResult>((Func<Context, TResult>)FaultLambda, InjectionRateLambda, enabled);
+            return new InjectOutcomePolicy<TResult>((Func<Context, CancellationToken, TResult>)FaultLambda, InjectionRateLambda, enabled);
         }
 
         /// <summary>
@@ -191,9 +192,9 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectOutcomePolicy<TResult> InjectFault<TResult>(
-            Func<Context, TResult> faultProvider,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, TResult> faultProvider,
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (faultProvider == null) throw new ArgumentNullException(nameof(faultProvider));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/Fault/InjectOutcomePolicy.cs
+++ b/src/Polly.Contrib.Simmy/Fault/InjectOutcomePolicy.cs
@@ -9,9 +9,9 @@ namespace Polly.Contrib.Simmy.Fault
     /// </summary>
     public class InjectOutcomePolicy : Simmy.MonkeyPolicy
     {
-        private readonly Func<Context, Exception> _faultProvider;
+        private readonly Func<Context, CancellationToken, Exception> _faultProvider;
 
-        internal InjectOutcomePolicy(Func<Context, Exception> faultProvider, Func<Context, double> injectionRate, Func<Context, bool> enabled) 
+        internal InjectOutcomePolicy(Func<Context, CancellationToken, Exception> faultProvider, Func<Context, CancellationToken, double> injectionRate, Func<Context, CancellationToken, bool> enabled) 
             : base(injectionRate, enabled)
         {
             _faultProvider = faultProvider ?? throw new ArgumentNullException(nameof(faultProvider));
@@ -35,16 +35,16 @@ namespace Polly.Contrib.Simmy.Fault
     /// </summary>
     public class InjectOutcomePolicy<TResult> : MonkeyPolicy<TResult>
     {
-        private readonly Func<Context, Exception> _faultProvider;
-        private readonly Func<Context, TResult> _resultProvider;
+        private readonly Func<Context, CancellationToken, Exception> _faultProvider;
+        private readonly Func<Context, CancellationToken, TResult> _resultProvider;
 
-        internal InjectOutcomePolicy(Func<Context, Exception> faultProvider, Func<Context, double> injectionRate, Func<Context, bool> enabled)
+        internal InjectOutcomePolicy(Func<Context, CancellationToken, Exception> faultProvider, Func<Context, CancellationToken, double> injectionRate, Func<Context, CancellationToken, bool> enabled)
             : base(injectionRate, enabled)
         {
             _faultProvider = faultProvider ?? throw new ArgumentNullException(nameof(faultProvider));
         }
 
-        internal InjectOutcomePolicy(Func<Context, TResult> resultProvider, Func<Context, double> injectionRate, Func<Context, bool> enabled)
+        internal InjectOutcomePolicy(Func<Context, CancellationToken, TResult> resultProvider, Func<Context, CancellationToken, double> injectionRate, Func<Context, CancellationToken, bool> enabled)
             : base(injectionRate, enabled)
         {
             _resultProvider = resultProvider ?? throw new ArgumentNullException(nameof(resultProvider));

--- a/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs
+++ b/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs
@@ -14,8 +14,8 @@ namespace Polly.Contrib.Simmy.Latency
 
         internal AsyncInjectLatencyPolicy(
             Func<Context, CancellationToken, Task<TimeSpan>> latencyProvider,
-            Func<Context, Task<Double>> injectionRate, 
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate, 
+            Func<Context, CancellationToken, Task<bool>> enabled)
             : base(injectionRate, enabled)
         {
             _latencyProvider = latencyProvider ?? throw new ArgumentNullException(nameof(latencyProvider));
@@ -51,8 +51,8 @@ namespace Polly.Contrib.Simmy.Latency
 
         internal AsyncInjectLatencyPolicy(
             Func<Context, CancellationToken, Task<TimeSpan>> latencyProvider,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
             : base(injectionRate, enabled)
         {
             _latencyProvider = latencyProvider ?? throw new ArgumentNullException(nameof(latencyProvider));

--- a/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs
+++ b/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs
@@ -32,10 +32,16 @@ namespace Polly.Contrib.Simmy.Latency
                 action,
                 context,
                 cancellationToken,
-                async (ctx, ct) => await SystemClock.SleepAsync(
-                        await _latencyProvider(ctx, cancellationToken).ConfigureAwait(continueOnCapturedContext),
-                        InjectLatencyPolicy.DefaultCancellationForInjectedLatency)
-                    .ConfigureAwait(continueOnCapturedContext),
+                async (ctx, ct) =>
+                {
+                    var latency = await _latencyProvider(ctx, cancellationToken).ConfigureAwait(continueOnCapturedContext);
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await SystemClock.SleepAsync(
+                            latency,
+                            InjectLatencyPolicy.DefaultCancellationForInjectedLatency)
+                        .ConfigureAwait(continueOnCapturedContext);
+                },
                 InjectionRate,
                 Enabled,
                 continueOnCapturedContext);
@@ -69,10 +75,16 @@ namespace Polly.Contrib.Simmy.Latency
                 action,
                 context,
                 cancellationToken,
-                async (ctx, ct) => await SystemClock.SleepAsync(
-                    await _latencyProvider(ctx, cancellationToken).ConfigureAwait(continueOnCapturedContext),
-                        InjectLatencyPolicy.DefaultCancellationForInjectedLatency)
-                    .ConfigureAwait(continueOnCapturedContext),
+                async (ctx, ct) =>
+                {
+                    var latency = await _latencyProvider(ctx, cancellationToken).ConfigureAwait(continueOnCapturedContext);
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await SystemClock.SleepAsync(
+                            latency,
+                            InjectLatencyPolicy.DefaultCancellationForInjectedLatency)
+                        .ConfigureAwait(continueOnCapturedContext);
+                },
                 InjectionRate,
                 Enabled,
                 continueOnCapturedContext);

--- a/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs
+++ b/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs
@@ -35,8 +35,9 @@ namespace Polly.Contrib.Simmy.Latency
                 async (ctx, ct) =>
                 {
                     var latency = await _latencyProvider(ctx, cancellationToken).ConfigureAwait(continueOnCapturedContext);
-                    cancellationToken.ThrowIfCancellationRequested();
 
+                    // to prevent inject latency if token was signaled on latency configuration delegate.
+                    cancellationToken.ThrowIfCancellationRequested();
                     await SystemClock.SleepAsync(
                             latency,
                             InjectLatencyPolicy.DefaultCancellationForInjectedLatency)
@@ -78,8 +79,9 @@ namespace Polly.Contrib.Simmy.Latency
                 async (ctx, ct) =>
                 {
                     var latency = await _latencyProvider(ctx, cancellationToken).ConfigureAwait(continueOnCapturedContext);
-                    cancellationToken.ThrowIfCancellationRequested();
 
+                    // to prevent inject latency if token was signaled on latency configuration delegate.
+                    cancellationToken.ThrowIfCancellationRequested();
                     await SystemClock.SleepAsync(
                             latency,
                             InjectLatencyPolicy.DefaultCancellationForInjectedLatency)

--- a/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencySyntax.cs
+++ b/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencySyntax.cs
@@ -23,8 +23,8 @@ namespace Polly.Contrib.Simmy
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<TimeSpan> LatencyProvider(Context _, CancellationToken __) => Task.FromResult(latency);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
-            Task<bool> EnabledLambda(Context _) => Task.FromResult(enabled());
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => Task.FromResult(enabled());
 
             return new AsyncInjectLatencyPolicy(LatencyProvider, InjectionRateLambda, EnabledLambda);
         }
@@ -40,12 +40,12 @@ namespace Polly.Contrib.Simmy
         public static AsyncInjectLatencyPolicy InjectLatencyAsync(
             TimeSpan latency,
             Double injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<TimeSpan> LatencyProvider(Context _, CancellationToken __) => Task.FromResult(latency);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
 
             return new AsyncInjectLatencyPolicy(LatencyProvider, InjectionRateLambda, enabled);
         }
@@ -60,8 +60,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectLatencyPolicy InjectLatencyAsync(
             TimeSpan latency,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
@@ -80,8 +80,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectLatencyPolicy InjectLatencyAsync(
             Func<Context, CancellationToken, Task<TimeSpan>> latency,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (latency == null) throw new ArgumentNullException(nameof(latency));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
@@ -109,8 +109,8 @@ namespace Polly.Contrib.Simmy
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<TimeSpan> LatencyProvider(Context _, CancellationToken __) => Task.FromResult(latency);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
-            Task<bool> EnabledLambda(Context _) => Task.FromResult(enabled());
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
+            Task<bool> EnabledLambda(Context _, CancellationToken __) => Task.FromResult(enabled());
 
             return new AsyncInjectLatencyPolicy<TResult>(LatencyProvider, InjectionRateLambda, EnabledLambda);
         }
@@ -126,12 +126,12 @@ namespace Polly.Contrib.Simmy
         public static AsyncInjectLatencyPolicy<TResult> InjectLatencyAsync<TResult>(
             TimeSpan latency,
             Double injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
             Task<TimeSpan> LatencyProvider(Context _, CancellationToken __) => Task.FromResult(latency);
-            Task<double> InjectionRateLambda(Context _) => Task.FromResult(injectionRate);
+            Task<double> InjectionRateLambda(Context _, CancellationToken __) => Task.FromResult(injectionRate);
 
             return new AsyncInjectLatencyPolicy<TResult>(LatencyProvider, InjectionRateLambda, enabled);
         }
@@ -146,8 +146,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectLatencyPolicy<TResult> InjectLatencyAsync<TResult>(
             TimeSpan latency,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
@@ -166,8 +166,8 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static AsyncInjectLatencyPolicy<TResult> InjectLatencyAsync<TResult>(
             Func<Context, CancellationToken, Task<TimeSpan>> latency,
-            Func<Context, Task<Double>> injectionRate,
-            Func<Context, Task<bool>> enabled)
+            Func<Context, CancellationToken, Task<Double>> injectionRate,
+            Func<Context, CancellationToken, Task<bool>> enabled)
         {
             if (latency == null) throw new ArgumentNullException(nameof(latency));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/Latency/InjectLatencyPolicy.cs
+++ b/src/Polly.Contrib.Simmy/Latency/InjectLatencyPolicy.cs
@@ -11,12 +11,12 @@ namespace Polly.Contrib.Simmy.Latency
     {
         internal static readonly CancellationToken DefaultCancellationForInjectedLatency = CancellationToken.None; // It is intended that injected latency is not susceptible to cancellation. (TO CONFIRM)
 
-        private readonly Func<Context, TimeSpan> _latencyProvider;
+        private readonly Func<Context, CancellationToken, TimeSpan> _latencyProvider;
 
         internal InjectLatencyPolicy(
-            Func<Context, TimeSpan> latencyProvider,
-            Func<Context, double> injectionRate, 
-            Func<Context, bool> enabled) 
+            Func<Context, CancellationToken, TimeSpan> latencyProvider,
+            Func<Context, CancellationToken, double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
             : base(injectionRate, enabled)
         {
             _latencyProvider = latencyProvider ?? throw new ArgumentNullException(nameof(latencyProvider));
@@ -29,7 +29,14 @@ namespace Polly.Contrib.Simmy.Latency
                 action,
                 context,
                 cancellationToken,
-                (ctx, ct) => SystemClock.Sleep(_latencyProvider(ctx), DefaultCancellationForInjectedLatency),
+                (ctx, ct) =>
+                {
+                    var latency = _latencyProvider(ctx, ct);
+
+                    // to prevent inject latency if token was signaled on latency configuration delegate.
+                    cancellationToken.ThrowIfCancellationRequested();
+                    SystemClock.Sleep(latency, DefaultCancellationForInjectedLatency);
+                },
                 InjectionRate,
                 Enabled);
         }
@@ -41,12 +48,12 @@ namespace Polly.Contrib.Simmy.Latency
     /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
     public class InjectLatencyPolicy<TResult> : MonkeyPolicy<TResult>
     {
-        private readonly Func<Context, TimeSpan> _latencyProvider;
+        private readonly Func<Context, CancellationToken, TimeSpan> _latencyProvider;
 
         internal InjectLatencyPolicy(
-            Func<Context, TimeSpan> latencyProvider,
-            Func<Context, double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, TimeSpan> latencyProvider,
+            Func<Context, CancellationToken, double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
             : base(injectionRate, enabled)
         {
             _latencyProvider = latencyProvider ?? throw new ArgumentNullException(nameof(latencyProvider));
@@ -59,7 +66,14 @@ namespace Polly.Contrib.Simmy.Latency
                 action,
                 context,
                 cancellationToken,
-                (ctx, ct) => SystemClock.Sleep(_latencyProvider(ctx), InjectLatencyPolicy.DefaultCancellationForInjectedLatency),
+                (ctx, ct) =>
+                {
+                    var latency = _latencyProvider(ctx, ct);
+
+                    // to prevent inject latency if token was signaled on latency configuration delegate.
+                    cancellationToken.ThrowIfCancellationRequested();
+                    SystemClock.Sleep(latency, InjectLatencyPolicy.DefaultCancellationForInjectedLatency);
+                },
                 InjectionRate,
                 Enabled);
         }

--- a/src/Polly.Contrib.Simmy/Latency/InjectLatencySyntax.cs
+++ b/src/Polly.Contrib.Simmy/Latency/InjectLatencySyntax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Polly.Contrib.Simmy.Latency;
 
 namespace Polly.Contrib.Simmy
@@ -20,7 +21,7 @@ namespace Polly.Contrib.Simmy
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            return new InjectLatencyPolicy(_ => latency, _ => injectionRate, _ => enabled());
+            return new InjectLatencyPolicy((_, __) => latency, (_, __) => injectionRate, (_, __) => enabled());
         }
 
         /// <summary>
@@ -34,11 +35,11 @@ namespace Polly.Contrib.Simmy
         public static InjectLatencyPolicy InjectLatency(
             TimeSpan latency,
             Double injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            return new InjectLatencyPolicy(_ => latency, _ => injectionRate, enabled);
+            return new InjectLatencyPolicy((_, __) => latency, (_, __) => injectionRate, enabled);
         }
 
         /// <summary>
@@ -51,13 +52,13 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static InjectLatencyPolicy InjectLatency(
             TimeSpan latency,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            return new InjectLatencyPolicy(_ => latency, injectionRate, enabled);
+            return new InjectLatencyPolicy((_, __) => latency, injectionRate, enabled);
         }
 
         /// <summary>
@@ -69,14 +70,14 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectLatencyPolicy InjectLatency(
-            Func<Context, TimeSpan> latency,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, TimeSpan> latency,
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (latency == null) throw new ArgumentNullException(nameof(latency));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
-            
+
             return new InjectLatencyPolicy(latency, injectionRate, enabled);
         }
     }
@@ -98,7 +99,7 @@ namespace Polly.Contrib.Simmy
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            return new InjectLatencyPolicy<TResult>(_ => latency, _ => injectionRate, _ => enabled());
+            return new InjectLatencyPolicy<TResult>((_, __) => latency, (_, __) => injectionRate, (_, __) => enabled());
         }
 
         /// <summary>
@@ -112,11 +113,11 @@ namespace Polly.Contrib.Simmy
         public static InjectLatencyPolicy<TResult> InjectLatency<TResult>(
             TimeSpan latency,
             Double injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            return new InjectLatencyPolicy<TResult>(_ => latency, _ => injectionRate, enabled);
+            return new InjectLatencyPolicy<TResult>((_, __) => latency, (_, __) => injectionRate, enabled);
         }
 
         /// <summary>
@@ -129,13 +130,13 @@ namespace Polly.Contrib.Simmy
         /// <returns>The policy instance.</returns>
         public static InjectLatencyPolicy<TResult> InjectLatency<TResult>(
             TimeSpan latency,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));
             if (enabled == null) throw new ArgumentNullException(nameof(enabled));
 
-            return new InjectLatencyPolicy<TResult>(_ => latency, injectionRate, enabled);
+            return new InjectLatencyPolicy<TResult>((_, __) => latency, injectionRate, enabled);
         }
 
         /// <summary>
@@ -147,9 +148,9 @@ namespace Polly.Contrib.Simmy
         /// <param name="enabled">Lambda to check if this policy is enabled in current context</param>
         /// <returns>The policy instance.</returns>
         public static InjectLatencyPolicy<TResult> InjectLatency<TResult>(
-            Func<Context, TimeSpan> latency,
-            Func<Context, Double> injectionRate,
-            Func<Context, bool> enabled)
+            Func<Context, CancellationToken, TimeSpan> latency,
+            Func<Context, CancellationToken, Double> injectionRate,
+            Func<Context, CancellationToken, bool> enabled)
         {
             if (latency == null) throw new ArgumentNullException(nameof(latency));
             if (injectionRate == null) throw new ArgumentNullException(nameof(injectionRate));

--- a/src/Polly.Contrib.Simmy/MonkeyPolicy.cs
+++ b/src/Polly.Contrib.Simmy/MonkeyPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Polly.Contrib.Simmy
 {
@@ -7,11 +8,11 @@ namespace Polly.Contrib.Simmy
     /// </summary>
     public abstract partial class MonkeyPolicy : Policy, IMonkeyPolicy
     {
-        internal Func<Context, Double> InjectionRate { get; }
+        internal Func<Context, CancellationToken, Double> InjectionRate { get; }
 
-        internal Func<Context, bool> Enabled { get; }
+        internal Func<Context, CancellationToken, bool> Enabled { get; }
 
-        internal MonkeyPolicy(Func<Context, Double> injectionRate, Func<Context, bool> enabled)
+        internal MonkeyPolicy(Func<Context, CancellationToken, Double> injectionRate, Func<Context, CancellationToken, bool> enabled)
         {
             InjectionRate = injectionRate ?? throw new ArgumentNullException(nameof(injectionRate));
             Enabled = enabled ?? throw new ArgumentNullException(nameof(enabled));
@@ -24,11 +25,11 @@ namespace Polly.Contrib.Simmy
     /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
     public abstract class MonkeyPolicy<TResult> : Policy<TResult>, IMonkeyPolicy<TResult>
     {
-        internal Func<Context, Double> InjectionRate { get; }
+        internal Func<Context, CancellationToken, Double> InjectionRate { get; }
 
-        internal Func<Context, bool> Enabled { get; }
+        internal Func<Context, CancellationToken, bool> Enabled { get; }
 
-        internal MonkeyPolicy(Func<Context, Double> injectionRate, Func<Context, bool> enabled) 
+        internal MonkeyPolicy(Func<Context, CancellationToken, Double> injectionRate, Func<Context, CancellationToken, bool> enabled)
         {
             InjectionRate = injectionRate ?? throw new ArgumentNullException(nameof(injectionRate));
             Enabled = enabled ?? throw new ArgumentNullException(nameof(enabled));


### PR DESCRIPTION
@reisenberger I updated the overloads which were taking the `Context` in configuration-providing delegates instead of adding new overloads (breaking change), basically to avoid the proliferation of the overloads as we discussed it previously, but it might be solved with the new syntax tho.

I added some validations on `AsyncMonkeyEngine` (not sure if that is correct) in order to avoid to execute extra code when the cancellation token is signaled at different times during the execution.

* [Before the execution starts](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs#L18)
* [When the user cancels execution on `enable` configuration delegate](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs#L26)
* [When the user cancels execution on `injectionRate `configuration delegate](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs#L31)
* [When a user cancels execution on `injectedBehaviour ` delegate](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs#L60) (This is not a configuration delegate but the user might want to cancel the original action after to inject a custom behavior)
* [When user cancels execution on `injectedException ` configuration delegate](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs#L78)

I also changed the `AsyncInjectLatencyPolicy` ([1](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs#L37), [2](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/Latency/AsyncInjectLatencyPolicy.cs#L80)) in order to make the latency configuration delegate cancellable because it was injecting the latency even though you signal the cancellation from that configuration delegate.

However, after this refactor I have a big doubt: should we let the cancellation token request flow to the user rather than let Simmy does it using `ThrowIfCancellationRequested()` on `AsyncMonkeyEngine`? if not, I'll need to update the `MonkeyEngine` as well (to put those validations).

Or just validate once on `ShouldInjectAsync ` method at the [beginning](https://github.com/Polly-Contrib/Simmy/blob/e56484acaa14fcf7c40b714cbb2e9212d23cfcc5/src/Polly.Contrib.Simmy/AsyncMonkeyEngine.cs#L18)? and let the user does something like this:

```
Func<Context, CancellationToken, Task> actionOrConfigDelegateAsync = (ctx, ct) =>
{
     ct.ThrowIfCancellationRequested();
     ...
};
```

Thoughts?

ref #19