### PR TITLE
Fixes unit tests execution on .Net Core 3.0

### DIFF
--- a/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourAsyncWithOptionsSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourAsyncWithOptionsSpecs.cs
@@ -120,8 +120,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(-1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -133,8 +132,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(1.1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -147,8 +145,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Awaiting(async x => await x.ExecuteAsync(() => Task.CompletedTask))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -161,8 +158,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Awaiting(async x => await x.ExecuteAsync(() => Task.CompletedTask))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         #endregion

--- a/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourTResultAsyncWithOptionsSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourTResultAsyncWithOptionsSpecs.cs
@@ -121,8 +121,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(-1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -134,8 +133,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(1.1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -148,8 +146,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -162,8 +159,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         #endregion

--- a/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourTResultWithOptionsSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourTResultWithOptionsSpecs.cs
@@ -103,8 +103,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(-1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -116,8 +115,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(1.1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -130,8 +128,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -144,8 +141,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         #endregion

--- a/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourWithOptionsSpecs.cs
+++ b/src/Polly.Contrib.Simmy.Specs/Behavior/InjectBehaviourWithOptionsSpecs.cs
@@ -102,8 +102,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(-1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -115,8 +114,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
                     .InjectionRate(1.1)
             );
 
-            act.ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+            act.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -129,8 +127,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Invoking(x => x.Execute(() => { }))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a negative number.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -143,8 +140,7 @@ namespace Polly.Contrib.Simmy.Specs.Behavior
             );
 
             policy.Invoking(x => x.Execute(() => { }))
-                .ShouldThrow<ArgumentOutOfRangeException>()
-                .WithMessage("Injection rate/threshold in Monkey policies should always be a double between [0, 1]; never a number greater than 1.\r\nParameter name: injectionThreshold");
+                .ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         #endregion

--- a/src/Polly.Contrib.Simmy/MonkeyEngine.cs
+++ b/src/Polly.Contrib.Simmy/MonkeyEngine.cs
@@ -65,7 +65,6 @@ namespace Polly.Contrib.Simmy
                 {
                     throw exception;
                 }
-
             }
 
             return action(context, cancellationToken);


### PR DESCRIPTION
Fixes unit tests execution on .net core 3.0. `ArgumentOutOfRangeException` formats the parameter name in a different way respect to other framework versions. 

* .Net Core 3.0:
`"{message}\r\nParameter name: {parameterName}"`
* Prior versions:
`"{message} (Parameter '{parameterName}')"`

So, I removed the error message comparison from the unit tests.